### PR TITLE
removed errant comma in dodge

### DIFF
--- a/lua/lib/tweak_data/charactertweakdata.lua
+++ b/lua/lib/tweak_data/charactertweakdata.lua
@@ -94,7 +94,7 @@ function CharacterTweakData:_presets(tweak_data)
 					roll = {
 						chance = 3,
 						timeout = {1.2, 2}
-					},
+					}
 				}
 			}
 		}


### PR DESCRIPTION
A comma was left over in the last entry in a series in a dodge preset, unlikely but possible crash issue?

For some reason this is showing an additional change at the end of the file, please make sure I didn't fuck the file up with this one.