### PR TITLE
Damage revisions

### DIFF
--- a/lua/lib/tweak_data/weapontweakdata.lua
+++ b/lua/lib/tweak_data/weapontweakdata.lua
@@ -19,7 +19,7 @@ function WeaponTweakData:init(tweak_data)
 
 	self.deathvox_light_ar.sounds.prefix = "aug_npc" -- dont worry about this
 	self.deathvox_light_ar.use_data.selection_index = 2 -- dont worry about this
-	self.deathvox_light_ar.DAMAGE = 7.75 -- Base damage 77.5.
+	self.deathvox_light_ar.DAMAGE = 7.5 -- Base damage 75.
 	self.deathvox_light_ar.muzzleflash = "effects/payday2/particles/weapons/556_auto" -- dont worry about this
 	self.deathvox_light_ar.shell_ejection = "effects/payday2/particles/weapons/shells/shell_556" -- dont worry about this
 	self.deathvox_light_ar.CLIP_AMMO_MAX = 30 -- How many shots before they gotta reload
@@ -37,7 +37,7 @@ function WeaponTweakData:init(tweak_data)
 
 	self.deathvox_heavy_ar.sounds.prefix = "fn_fal_npc"
 	self.deathvox_heavy_ar.use_data.selection_index = 2
-	self.deathvox_heavy_ar.DAMAGE = 8.75 -- base damage 87.5.
+	self.deathvox_heavy_ar.DAMAGE = 10 -- base damage 100.
 	self.deathvox_heavy_ar.muzzleflash = "effects/payday2/particles/weapons/762_auto"
 	self.deathvox_heavy_ar.shell_ejection = "effects/payday2/particles/weapons/shells/shell_556"
 	self.deathvox_heavy_ar.CLIP_AMMO_MAX = 20
@@ -79,11 +79,11 @@ function WeaponTweakData:init(tweak_data)
 	self.deathvox_medic_pistol.suppression = 1.8
 	self.deathvox_medic_pistol.usage = "is_revolver"
 	self.deathvox_medic_pistol.anim_usage = "is_revolver"
-	self.deathvox_medic_pistol.armor_piercing = true
+	self.deathvox_medic_pistol.armor_piercing = true -- armor piercing.
 
 	self.deathvox_shotgun_light.sounds.prefix = "remington_npc"
 	self.deathvox_shotgun_light.use_data.selection_index = 2
-	self.deathvox_shotgun_light.DAMAGE = 8.75 -- Base damage 87.5.
+	self.deathvox_shotgun_light.DAMAGE = 9 -- Base damage 90.
 	self.deathvox_shotgun_light.muzzleflash = "effects/payday2/particles/weapons/762_auto"
 	self.deathvox_shotgun_light.shell_ejection = "effects/payday2/particles/weapons/shells/shell_slug_semi"
 	self.deathvox_shotgun_light.CLIP_AMMO_MAX = 6
@@ -97,7 +97,7 @@ function WeaponTweakData:init(tweak_data)
 
 	self.deathvox_shotgun_heavy.sounds.prefix = "benelli_m4_npc"
 	self.deathvox_shotgun_heavy.use_data.selection_index = 2
-	self.deathvox_shotgun_heavy.DAMAGE = 13 -- Base damage 130
+	self.deathvox_shotgun_heavy.DAMAGE = 13 -- Base damage 130.
 	self.deathvox_shotgun_heavy.muzzleflash = "effects/payday2/particles/weapons/762_auto"
 	self.deathvox_shotgun_heavy.shell_ejection = "effects/payday2/particles/weapons/shells/shell_slug"
 	self.deathvox_shotgun_heavy.auto.fire_rate = 0.14
@@ -114,7 +114,7 @@ function WeaponTweakData:init(tweak_data)
 
 	self.deathvox_sniper.sounds.prefix = "lakner_npc"
 	self.deathvox_sniper.use_data.selection_index = 2
-	self.deathvox_sniper.DAMAGE = 35 -- base 240, drop with distance, check other vals.
+	self.deathvox_sniper.DAMAGE = 24 -- base 240, drop with distance. Same as DW and OD.
 	self.deathvox_sniper.muzzleflash = "effects/payday2/particles/weapons/9mm_auto"
 	self.deathvox_sniper.muzzleflash_silenced = "effects/payday2/particles/weapons/9mm_auto_silence"
 	self.deathvox_sniper.shell_ejection = "effects/payday2/particles/weapons/shells/shell_9mm"
@@ -135,7 +135,7 @@ function WeaponTweakData:init(tweak_data)
 	
 	self.deathvox_medicdozer_smg.sounds.prefix = "polymer_npc"
 	self.deathvox_medicdozer_smg.use_data.selection_index = 1
-	self.deathvox_medicdozer_smg.DAMAGE = 6.5 -- Vanilla base is 20, adjusting up to 65.
+	self.deathvox_medicdozer_smg.DAMAGE = 4.5 -- Vanilla base is 20, adjusting up to 45. Matched to other smgs.
 	self.deathvox_medicdozer_smg.muzzleflash = "effects/payday2/particles/weapons/9mm_auto"
 	self.deathvox_medicdozer_smg.muzzleflash_silenced = "effects/payday2/particles/weapons/9mm_auto_silence"
 	self.deathvox_medicdozer_smg.shell_ejection = "effects/payday2/particles/weapons/shells/shell_9mm"
@@ -154,7 +154,7 @@ function WeaponTweakData:init(tweak_data)
 	
 	self.deathvox_grenadier.sounds.prefix = "contraband_npc"
 	self.deathvox_grenadier.use_data.selection_index = 2
-	self.deathvox_grenadier.DAMAGE = 7
+	self.deathvox_grenadier.DAMAGE = 7.5 -- Base damage 75. Matched to light swat.
 	self.deathvox_grenadier.muzzleflash = "effects/payday2/particles/weapons/762_auto"
 	self.deathvox_grenadier.shell_ejection = "effects/payday2/particles/weapons/shells/shell_556"
 	self.deathvox_grenadier.CLIP_AMMO_MAX = 20
@@ -171,7 +171,7 @@ function WeaponTweakData:init(tweak_data)
 	
     self.deathvox_lmgdozer.sounds.prefix = "m249_npc"
     self.deathvox_lmgdozer.use_data.selection_index = 2
-    self.deathvox_lmgdozer.DAMAGE = 10
+    self.deathvox_lmgdozer.DAMAGE = 10 -- Base damage 100, matched to DW.
     self.deathvox_lmgdozer.muzzleflash = "effects/payday2/particles/weapons/big_762_auto"
     self.deathvox_lmgdozer.shell_ejection = "effects/payday2/particles/weapons/shells/shell_556_lmg"
     self.deathvox_lmgdozer.CLIP_AMMO_MAX = 200
@@ -184,7 +184,7 @@ function WeaponTweakData:init(tweak_data)
    
     self.deathvox_cloaker.sounds.prefix = "schakal_npc"
     self.deathvox_cloaker.use_data.selection_index = 1
-    self.deathvox_cloaker.DAMAGE = 6.5
+    self.deathvox_cloaker.DAMAGE = 4.5 -- Base damage 45, matched to other smgs
     self.deathvox_cloaker.muzzleflash = "effects/payday2/particles/weapons/9mm_auto"
     self.deathvox_cloaker.muzzleflash_silenced = "effects/payday2/particles/weapons/9mm_auto_silence"
     self.deathvox_cloaker.shell_ejection = "effects/payday2/particles/weapons/shells/shell_9mm"
@@ -203,7 +203,7 @@ function WeaponTweakData:init(tweak_data)
    
     self.deathvox_blackdozer.sounds.prefix = "saiga_npc"
     self.deathvox_blackdozer.use_data.selection_index = 2
-    self.deathvox_blackdozer.DAMAGE = 22.5
+    self.deathvox_blackdozer.DAMAGE = 22.5 --Base damage 225, matched to DW.
     self.deathvox_blackdozer.muzzleflash = "effects/payday2/particles/weapons/762_auto"
     self.deathvox_blackdozer.shell_ejection = "effects/payday2/particles/weapons/shells/shell_slug"
     self.deathvox_blackdozer.auto.fire_rate = 0.14
@@ -217,7 +217,7 @@ function WeaponTweakData:init(tweak_data)
    
     self.deathvox_greendozer.sounds.prefix = "remington_npc"
     self.deathvox_greendozer.use_data.selection_index = 2
-    self.deathvox_greendozer.DAMAGE = 40
+    self.deathvox_greendozer.DAMAGE = 45 --Base damage 450, Compare DW 400, OD 560.
     self.deathvox_greendozer.muzzleflash = "effects/payday2/particles/weapons/762_auto"
     self.deathvox_greendozer.shell_ejection = "effects/payday2/particles/weapons/shells/shell_slug_semi"
     self.deathvox_greendozer.CLIP_AMMO_MAX = 6


### PR DESCRIPTION
Damage revisions across several categories. Rationales follow.
Snipers use their DW damage, going higher on CD will make them instakill under too many circumstances.
Smg damage lowered back to 45 for now (base weapon threat is not a significant factor in enemies that use them, will revisit later.
light and heavy swat weapons were revised bimodally (and generally upward), but are still below OD values. 
Bulldozer damage matched to DW, aside from green dozers, which have had their values placed between DW and OD.