### PR TITLE
Update assets.xml for new version of SuperBLT

### DIFF
--- a/assets.xml
+++ b/assets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<assets base_path="assets/">
+<assets base_path="assets/" target="scripted" load_group="cops">
 	<group name="pd1_cops/">
 		<file :name="units/characters/enemies/tank/tank.object" force="false"/>
 		<file :name="units/characters/enemies/tank/tank.model" force="false"/>

--- a/assets.xml
+++ b/assets.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<assets :base_path="assets/">
+<assets base_path="assets/">
 	<group name="pd1_cops/">
 		<file :name="units/characters/enemies/tank/tank.object" force="false"/>
 		<file :name="units/characters/enemies/tank/tank.model" force="false"/>

--- a/lua/lib/tweak_data/charactertweakdata.lua
+++ b/lua/lib/tweak_data/charactertweakdata.lua
@@ -2030,7 +2030,10 @@ function CharacterTweakData:_init_deathvox(presets)
 	
 end
 
+local deathvox_mod_instance = ModInstance
 function CharacterTweakData:_set_sm_wish()
+	deathvox_mod_instance:GetSuperMod():GetAssetLoader():LoadAssetGroup("cops")
+
 	if SystemInfo:platform() == Idstring("PS3") then
 		self:_multiply_all_hp(1, 1)
 	else


### PR DESCRIPTION
The newest version of the SuperBLT Lua has a breaking change (I intend to make this the last breaking change) in the XML asset loader API. This PR updates to fix that, and also only loads assets when playing on the appropriate difficulty.