### PR TITLE
Removes some enemy revive anims

### DIFF
--- a/lua/lib/tweak_data/charactertweakdata.lua
+++ b/lua/lib/tweak_data/charactertweakdata.lua
@@ -1689,6 +1689,7 @@ end
 function CharacterTweakData:_init_deathvox(presets)
 	self.deathvox_guard = deep_clone(self.security)
 	self.deathvox_guard.detection = presets.detection.guard
+	self.deathvox_guard.ignore_medic_revive_animation = true --no revive animation.
 	self.deathvox_guard.suppression = nil -- presets.suppression.no_supress
 	self.deathvox_guard.surrender = presets.surrender.easy
 	self.deathvox_guard.move_speed = presets.move_speed.very_fast -- tentative.
@@ -1707,6 +1708,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	
 	self.deathvox_lightar = deep_clone(self.city_swat)
 	self.deathvox_lightar.detection = presets.detection.normal
+	self.deathvox_lightar.ignore_medic_revive_animation = true  --no revive animation.
 	self.deathvox_lightar.suppression = presets.suppression.hard_agg
 	self.deathvox_lightar.surrender = presets.surrender.normal -- hard for heavy, normal for light.
 	self.deathvox_lightar.move_speed = presets.move_speed.very_fast
@@ -1730,6 +1732,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	
 	self.deathvox_heavyar = deep_clone(self.city_swat)
 	self.deathvox_heavyar.detection = presets.detection.normal
+	self.deathvox_heavyar.ignore_medic_revive_animation = true  --no revive animation.
 	self.deathvox_heavyar.damage.hurt_severity = presets.hurt_severities.light_hurt_fire_poison -- revised per feedback.
 	self.deathvox_heavyar.suppression = presets.suppression.hard_agg -- tentative.
 	self.deathvox_heavyar.surrender = presets.surrender.hard --tentative.
@@ -1755,6 +1758,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	
 	self.deathvox_lightshot = deep_clone(self.city_swat)
 	self.deathvox_lightshot.detection = presets.detection.normal
+	self.deathvox_lightshot.ignore_medic_revive_animation = true  --no revive animation.
 	self.deathvox_lightshot.suppression = presets.suppression.hard_agg -- tentative.
 	self.deathvox_lightshot.surrender = presets.surrender.normal -- tentative.
 	self.deathvox_lightshot.move_speed = presets.move_speed.very_fast
@@ -1778,6 +1782,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	
 	self.deathvox_heavyshot = deep_clone(self.city_swat)
 	self.deathvox_heavyshot.detection = presets.detection.normal
+	self.deathvox_heavyshot.ignore_medic_revive_animation = true  --no revive animation.
 	self.deathvox_heavyshot.damage.hurt_severity = presets.hurt_severities.light_hurt_fire_poison -- revised per feedback.
 	self.deathvox_heavyshot.suppression = presets.suppression.hard_agg -- tentative.
 	self.deathvox_heavyshot.surrender = presets.surrender.hard -- tentative.
@@ -1804,6 +1809,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	self.deathvox_shield = deep_clone(self.shield)
 	self.deathvox_shield.tags = {"shield"} -- just to be sure it's being applied.
 	self.deathvox_shield.detection = presets.detection.normal
+	self.deathvox_shield.ignore_medic_revive_animation = true  --no revive animation. In base.
 	self.deathvox_shield.damage.hurt_severity = presets.hurt_severities.only_explosion_hurts
 	self.deathvox_shield.suppression = presets.suppression.no_supress -- I think this is in resto, if not it now is.
 	self.deathvox_shield.surrender = nil
@@ -1826,6 +1832,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	self.deathvox_medic = deep_clone(self.medic)
 	self.deathvox_medic.tags = {"medic"} --just making sure tag applies.
 	self.deathvox_medic.detection = presets.detection.normal
+	self.deathvox_medic.ignore_medic_revive_animation = true  --no revive animation.
 	self.deathvox_medic.damage.hurt_severity = presets.hurt_severities.only_fire_and_poison_hurts -- added to make code consistent.
 	self.deathvox_medic.suppression = presets.suppression.no_supress -- in base.
 	self.deathvox_medic.surrender = nil -- correcting surrender bug.
@@ -1853,6 +1860,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	self.deathvox_taser = deep_clone(self.taser)
 	self.deathvox_taser.tags = {"taser"} -- just making sure tag applies.
 	self.deathvox_taser.detection = presets.detection.normal
+	self.deathvox_taser.ignore_medic_revive_animation = true  --no revive animation.
 	self.deathvox_taser.damage.hurt_severity = presets.hurt_severities.only_light_hurt_and_fire
 	self.deathvox_taser.damage.hurt_severity.tase = false -- if this works, great, horrible things will arise.
 	self.deathvox_taser.suppression = presets.suppression.no_supress -- consistent form added.
@@ -1877,6 +1885,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	self.deathvox_cloaker = deep_clone(self.spooc)
 	self.deathvox_cloaker.tags = {"spooc"} -- just making sure tag applies.
 	self.deathvox_cloaker.detection = presets.detection.normal
+	self.deathvox_cloaker.ignore_medic_revive_animation = true  --no revive animation.
 	self.deathvox_cloaker.suppression = nil
 	self.deathvox_cloaker.surrender = nil
 	self.deathvox_cloaker.move_speed = presets.move_speed.lightning
@@ -1899,6 +1908,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	self.deathvox_sniper = deep_clone(self.sniper)
 	self.deathvox_sniper.tags = {"sniper"} -- just making sure tag applies.
 	self.deathvox_sniper.detection = presets.detection.normal
+	self.deathvox_sniper.ignore_medic_revive_animation = false  -- revive animation.
 	self.deathvox_sniper.suppression = presets.suppression.no_supress -- this actually makes snipers way less annoying!
 	self.deathvox_sniper.surrender = nil -- correcting surrender bug.
 	self.deathvox_sniper.move_speed = presets.move_speed.normal -- same as base.
@@ -1927,6 +1937,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	self.deathvox_tank = deep_clone(self.tank)
 	self.deathvox_tank.tags = {"tank"} -- just making sure tag applies.
 	self.deathvox_tank.detection = presets.detection.normal
+	self.deathvox_tank.ignore_medic_revive_animation = false  -- revive animation.
 	self.deathvox_tank.damage.hurt_severity = presets.hurt_severities.no_hurts_no_tase -- new with final 2017 pass. Probably not a change, needs to stay.
 	self.deathvox_tank.suppression = presets.suppression.no_supress
 	self.deathvox_tank.surrender = nil
@@ -1966,7 +1977,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	self.deathvox_medicdozer.tags = {"tank", "medic"}
 	self.deathvox_medicdozer.use_factory = true -- Use a factory weapon
 	self.deathvox_medicdozer.factory_weapon_id = {"wpn_deathvox_medicdozer_smg"} 
-	self.deathvox_medicdozer.dv_medic_heal = true -- dont touch, makes him use the death vox healing
+	self.deathvox_medicdozer.dv_medic_heal = true -- don't touch, makes him use the death vox healing
 	self.deathvox_medicdozer.custom_voicework = "medicdozer"
 	self.deathvox_medicdozer.access = "walk"
 	self.deathvox_medicdozer.disable_medic_heal_voice = true
@@ -1980,6 +1991,7 @@ function CharacterTweakData:_init_deathvox(presets)
 	self.deathvox_grenadier.melee_weapon_dmg_multiplier = 1
 	self.deathvox_grenadier.weapon_safety_range = 1000
 	self.deathvox_grenadier.detection = presets.detection.normal
+	self.deathvox_grenadier.ignore_medic_revive_animation = true  -- no revive animation.
 	self.deathvox_grenadier.damage.hurt_severity = presets.hurt_severities.only_light_hurt_and_fire -- immune to poison. new with final 2017 pass.
 	self.deathvox_grenadier.HEALTH_INIT = 101
 	self.deathvox_grenadier.HEALTH_SUICIDE_LIMIT = 0.25


### PR DESCRIPTION
Tanks keep revive animations, other Zeal enemies do not. Included false lines and commenting for documentation purposes. Note that shields cannot use the revive animation, even in base.