### PR TITLE
reversing error in grenadier spawngroups

### DIFF
--- a/lua/lib/tweak_data/groupaitweakdata.lua
+++ b/lua/lib/tweak_data/groupaitweakdata.lua
@@ -723,7 +723,7 @@ function GroupAITweakData:_init_enemy_spawn_groups(difficulty_index)
 					freq = 1,
 					amount_min = 2,
 					amount_max = 2,
-					tactics = self._tactics.deathvox_grenad_lead,
+					tactics = self._tactics.deathvox_grenad_follow,
 					rank = 1
 				}
 			}


### PR DESCRIPTION
issue with too much grenadier aggression, should help rate a bit.
Need to consider larger changes to atropos group.